### PR TITLE
only try to convert to json if there is a result

### DIFF
--- a/dialpad/client.py
+++ b/dialpad/client.py
@@ -53,10 +53,9 @@ class DialpadClient(object):
       data['cursor'] = response_json['cursor']
       response = self._raw_request(path, method, data, headers)
       response.raise_for_status()
-      if response != []:
-        response_json = response.json()
-        for i in response_json['items']:
-          yield i
+      response_json = response.json() or dict()
+      for i in response_json['items']:
+        yield i
 
   def _raw_request(self, path, method='GET', data=None, headers=None):
     url = self._url(*path)

--- a/dialpad/client.py
+++ b/dialpad/client.py
@@ -53,9 +53,10 @@ class DialpadClient(object):
       data['cursor'] = response_json['cursor']
       response = self._raw_request(path, method, data, headers)
       response.raise_for_status()
-      response_json = response.json()
-      for i in response_json['items']:
-        yield i
+      if response != []:
+        response_json = response.json()
+        for i in response_json['items']:
+          yield i
 
   def _raw_request(self, path, method='GET', data=None, headers=None):
     url = self._url(*path)

--- a/dialpad/client.py
+++ b/dialpad/client.py
@@ -54,7 +54,7 @@ class DialpadClient(object):
       response = self._raw_request(path, method, data, headers)
       response.raise_for_status()
       response_json = response.json() or dict()
-      for i in response_json['items']:
+      for i in response_json.get('items', []):
         yield i
 
   def _raw_request(self, path, method='GET', data=None, headers=None):


### PR DESCRIPTION
this prevents the api from erroring if an empty result is returned for a cursor which is a failure case we have been experiencing