### PR TITLE
Changed to specify character encoding (UTF-8) when opening README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 def readme():
-  with open('README.md') as f:
+  with open('README.md', encoding='utf-8') as f:
     return f.read()
 
 


### PR DESCRIPTION
In some Windows environments, a character encoding other than UTF-8 is selected by default when opening files in Python, which may cause a UnicodeDecodeError during package installation.

To resolve this issue, a change has been made to explicitly specify UTF-8 when opening README.md.

Reference
[Changing the “locale preferred encoding” in Python 3 in Windows](https://stackoverflow.com/questions/31469707/changing-the-locale-preferred-encoding-in-python-3-in-windows)