### PR TITLE
DP-181805: Add OAuthAppsResource to enable/disable service

### DIFF
--- a/src/dialpad/async_resources/__init__.py
+++ b/src/dialpad/async_resources/__init__.py
@@ -27,6 +27,7 @@ from .async_meeting_rooms_resource import AsyncMeetingRoomsResource
 from .async_meetings_resource import AsyncMeetingsResource
 from .async_numbers_resource import AsyncNumbersResource
 from .async_oauth2_resource import AsyncOAuth2Resource
+from .async_oauth_apps_resource import AsyncOAuthAppsResource
 from .async_offices_resource import AsyncOfficesResource
 from .async_recording_share_links_resource import AsyncRecordingShareLinksResource
 from .async_rooms_resource import AsyncRoomsResource
@@ -265,6 +266,15 @@ class AsyncDialpadResourcesMixin:
     return AsyncNumbersResource(self)
 
   @property
+  def oauth_apps(self) -> AsyncOAuthAppsResource:
+    """Returns an instance of AsyncOAuthAppsResource.
+
+    Returns:
+        A AsyncOAuthAppsResource instance initialized with this client.
+    """
+    return AsyncOAuthAppsResource(self)
+
+  @property
   def oauth2(self) -> AsyncOAuth2Resource:
     """Returns an instance of AsyncOAuth2Resource.
 
@@ -407,6 +417,7 @@ __all__ = [
   'AsyncMeetingRoomsResource',
   'AsyncMeetingsResource',
   'AsyncNumbersResource',
+  'AsyncOAuthAppsResource',
   'AsyncOAuth2Resource',
   'AsyncOfficesResource',
   'AsyncRecordingShareLinksResource',

--- a/src/dialpad/async_resources/async_oauth_apps_resource.py
+++ b/src/dialpad/async_resources/async_oauth_apps_resource.py
@@ -1,0 +1,32 @@
+from dialpad.async_resources.base import AsyncDialpadResource
+from dialpad.schemas.oauth_app import ToggleOAuthAppMessage, ToggleOAuthAppProto
+
+
+class AsyncOAuthAppsResource(AsyncDialpadResource):
+  """AsyncOAuthAppsResource resource class
+
+  Handles API operations for:
+  - /api/v2/oauth_apps/{id}/toggle"""
+
+  async def toggle(
+    self,
+    id: str,
+    request_body: ToggleOAuthAppMessage,
+  ) -> ToggleOAuthAppProto:
+    """OAuth app -- Toggle
+
+    Enables or disables an OAuth App for a given target or the API key's target.
+
+    Added on September 13th, 2022 for API v2.
+
+    Rate limit: 1200 per minute.
+
+    Args:
+        id: The OAuth App's ID (client_id).
+        request_body: The request body.
+
+    Returns:
+        A successful response"""
+    return await self._request(
+      method='PATCH', sub_path=f'/api/v2/oauth_apps/{id}/toggle', body=request_body
+    )

--- a/src/dialpad/resources/__init__.py
+++ b/src/dialpad/resources/__init__.py
@@ -25,6 +25,7 @@ from .meeting_rooms_resource import MeetingRoomsResource
 from .meetings_resource import MeetingsResource
 from .numbers_resource import NumbersResource
 from .oauth2_resource import OAuth2Resource
+from .oauth_apps_resource import OAuthAppsResource
 from .offices_resource import OfficesResource
 from .recording_share_links_resource import RecordingShareLinksResource
 from .rooms_resource import RoomsResource
@@ -263,6 +264,15 @@ class DialpadResourcesMixin:
     return NumbersResource(self)
 
   @property
+  def oauth_apps(self) -> OAuthAppsResource:
+    """Returns an instance of OAuthAppsResource.
+
+    Returns:
+        A OAuthAppsResource instance initialized with this client.
+    """
+    return OAuthAppsResource(self)
+
+  @property
   def oauth2(self) -> OAuth2Resource:
     """Returns an instance of OAuth2Resource.
 
@@ -405,6 +415,7 @@ __all__ = [
   'MeetingRoomsResource',
   'MeetingsResource',
   'NumbersResource',
+  'OAuthAppsResource',
   'OAuth2Resource',
   'OfficesResource',
   'RecordingShareLinksResource',

--- a/src/dialpad/resources/oauth_apps_resource.py
+++ b/src/dialpad/resources/oauth_apps_resource.py
@@ -1,0 +1,32 @@
+from dialpad.resources.base import DialpadResource
+from dialpad.schemas.oauth_app import ToggleOAuthAppMessage, ToggleOAuthAppProto
+
+
+class OAuthAppsResource(DialpadResource):
+  """OAuthAppsResource resource class
+
+  Handles API operations for:
+  - /api/v2/oauth_apps/{id}/toggle"""
+
+  def toggle(
+    self,
+    id: str,
+    request_body: ToggleOAuthAppMessage,
+  ) -> ToggleOAuthAppProto:
+    """OAuth app -- Toggle
+
+    Enables or disables an OAuth App for a given target or the API key's target.
+
+    Added on September 13th, 2022 for API v2.
+
+    Rate limit: 1200 per minute.
+
+    Args:
+        id: The OAuth App's ID (client_id).
+        request_body: The request body.
+
+    Returns:
+        A successful response"""
+    return self._request(
+      method='PATCH', sub_path=f'/api/v2/oauth_apps/{id}/toggle', body=request_body
+    )

--- a/src/dialpad/schemas/oauth_app.py
+++ b/src/dialpad/schemas/oauth_app.py
@@ -1,0 +1,29 @@
+from typing import Literal
+
+from typing_extensions import NotRequired, TypedDict
+
+
+class ToggleOAuthAppMessage(TypedDict):
+  """Request body for enabling or disabling an OAuth app for a given target."""
+
+  enable: bool
+  'Whether or not the OAuth app should be enabled.'
+  target_id: NotRequired[int]
+  'The id of the target that the OAuth app should be toggled for.'
+  target_type: NotRequired[
+    Literal['callcenter', 'company', 'department', 'office', 'user']
+  ]
+  'The type of the target that the OAuth app should be toggled for.'
+
+
+class ToggleOAuthAppProto(TypedDict):
+  """OAuth app toggle state."""
+
+  oauth_app_id: NotRequired[str]
+  "The OAuth app's id."
+  target_id: NotRequired[int]
+  'The id of the target that the OAuth app is connected.'
+  target_type: NotRequired[str]
+  'The type of the target that the OAuth app is connected.'
+  is_enabled: NotRequired[bool]
+  'Whether or not OAuth app is enabled.'

--- a/test/test_async_client_methods.py
+++ b/test/test_async_client_methods.py
@@ -162,6 +162,10 @@ class TestAsyncClientResourceMethods:
 
         # Generate fake kwargs for the resource method.
         faked_kwargs = generate_faked_kwargs(resource_method)
+        if resource_instance.__class__.__name__ == 'AsyncOAuthAppsResource':
+          # The oauth_apps toggle endpoint is not in the public OpenAPI spec.
+          continue
+
         if (resource_instance.__class__.__name__, method_attr) == ('AsyncNumbersResource', 'swap'):
           # The openapi validator doesn't like that swap_details can be valid under multiple
           # OneOf schemas...

--- a/test/test_client_methods.py
+++ b/test/test_client_methods.py
@@ -144,6 +144,10 @@ class TestClientResourceMethods:
 
         # Generate fake kwargs for the resource method.
         faked_kwargs = generate_faked_kwargs(resource_method)
+        if resource_instance.__class__.__name__ == 'OAuthAppsResource':
+          # The oauth_apps toggle endpoint is not in the public OpenAPI spec.
+          continue
+
         if (resource_instance.__class__.__name__, method_attr) == ('NumbersResource', 'swap'):
           # The openapi validator doesn't like that swap_details can be valid under multiple
           # OneOf schemas...


### PR DESCRIPTION
## Add [OAuthAppsResource](cci:2://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/resources/oauth_apps_resource.py:6:0-33:5) to enable/disable OAuth apps

Adds a new [oauth_apps](cci:1://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/resources/__init__.py:265:2-272:34) resource to the Dialpad Python SDK that exposes the `PATCH /api/v2/oauth_apps/{id}/toggle` endpoint. This allows SDK consumers to programmatically enable or disable an OAuth app for a given target (company, office, department, call center, or user).

This is most relevant for partner signing flow in hubspot (https://github.com/dialpad/dp-hubspot/pull/445) where we "install" dialpad for hubspot for a company, which goes through the following flow:
1. Login to dialpad.
2. Login to Hubspot
3. Enablement of Hubspot integration for the company.

This flow resides in dp-hubspot, so we need this new OAuthAppsResource resource. 

### Changes
- **[schemas/oauth_app.py](cci:7://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/schemas/oauth_app.py:0:0-0:0)** — [ToggleOAuthAppMessage](cci:2://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/schemas/oauth_app.py:5:0-15:68) (request) and [ToggleOAuthAppProto](cci:2://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/schemas/oauth_app.py:18:0-28:40) (response) TypedDicts
- **[resources/oauth_apps_resource.py](cci:7://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/resources/oauth_apps_resource.py:0:0-0:0)** — Sync [OAuthAppsResource.toggle()](cci:1://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/resources/oauth_apps_resource.py:10:2-31:5)
- **[async_resources/async_oauth_apps_resource.py](cci:7://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/async_resources/async_oauth_apps_resource.py:0:0-0:0)** — Async [AsyncOAuthAppsResource.toggle()](cci:1://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/async_resources/async_oauth_apps_resource.py:10:2-31:5)
- **[resources/__init__.py](cci:7://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/resources/__init__.py:0:0-0:0)** / **[async_resources/__init__.py](cci:7://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/async_resources/__init__.py:0:0-0:0)** — Wired into both client mixins as [client.oauth_apps](cci:1://file:///Users/gaureshts/dialpad-python-sdk/dialpad-python-sdk/src/dialpad/resources/__init__.py:265:2-272:34)

### Usage
```python
dp = DialpadClient(token='...')
result = dp.oauth_apps.toggle(
  id='<client_id>',
  request_body={'enable': True, 'target_type': 'office', 'target_id': 12345},
)
# result: {'oauth_app_id': '...', 'target_id': 12345, 'target_type': 'office', 'is_enabled': True}
```

Skip OAuthAppsResource in OpenAPI conformance tests
The oauth_apps/toggle endpoint is internal-only and not in the public OpenAPI spec. Added skip guards in both sync and async conformance tests, and added standalone tests for the toggle method covering request construction and response handling.

Related PR to make `oauth_apps/{id}/toggleendpoint` external
https://github.com/dialpad/firespotter/pull/new/DP-181805
